### PR TITLE
Augment README and Fix Meeting Link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _site/*
+.bundle/
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # pmix.github.io
 PMIx Forum web site
+
+## To Run a Copy Locally
+
+Install the dependencies with bundle:
+
+```terminal
+bundle config set --local path vendor/bundle
+bundle
+```
+
+Build and serve the site locally:
+
+```terminal
+bundle exec jekyll serve
+```
+
+Visit `http://localhost:4000` in your browser.

--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,7 @@ header_pages:
 #
 exclude:
     - excluded-misc
+    - vendor/
 #   - .sass-cache/
 #   - .jekyll-cache/
 #   - gemfiles/

--- a/code/index.md
+++ b/code/index.md
@@ -67,7 +67,7 @@ Developer’s Telecon
 The PMIx developers meet weekly on Thursdays at noon US Pacific to discuss
 the standard, implementation issues, and release roadmap. The meeting is
 open to all interested parties. Meeting information is available
-[here](https://www.open-mpi.org/pmix-recaptcha/).
+[here](https://recaptcha.open-mpi.org/pmix-recaptcha/).
 
 
 


### PR DESCRIPTION
Add instructions to the README for building with `bundle`, which requires updating the `.gitignore` and `_config.yml` to handle the sub-directories created by `bundle`.

Also update the developers meeting recaptcha link.